### PR TITLE
Reading configuration variables from environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "3.7"
 install:
+  - pip install git+https://github.com/hasgeek/flask-babelhg/
   - pip install -r requirements.txt
   - pip install -r test_requirements.txt
 script:

--- a/instance/settings-sample.py
+++ b/instance/settings-sample.py
@@ -1,46 +1,46 @@
 # -*- coding: utf-8 -*-
+import os
+import json
+
 #: Site title
-SITE_TITLE = 'HasGeek App'
+SITE_TITLE = os.environ.get('SITE_TITLE', 'HasGeek App')
 #: Site id (for network bar)
-SITE_ID = ''
+SITE_ID = os.environ.get('SITE_ID', '')
 #: Google Analytics code
-GA_CODE = ''
+GA_CODE = os.environ.get('GA_CODE', '')
 #: Google site verification code (inserted as a meta tag)
-GOOGLE_SITE_VERIFICATION = ''
+GOOGLE_SITE_VERIFICATION = os.environ.get('GOOGLE_SITE_VERIFICATION', '')
 #: Typekit code
-TYPEKIT_CODE = ''
+TYPEKIT_CODE = os.environ.get('TYPEKIT_CODE', '')
 #: Database backend
-SQLALCHEMY_DATABASE_URI = 'sqlite:///test.db'
+SQLALCHEMY_DATABASE_URI = os.environ.get('SQLALCHEMY_DATABASE_URI', 'sqlite:///test.db')
 #: Asset server
-ASSET_SERVER = 'https://static.hasgeek.co.in/'
+ASSET_SERVER = os.environ.get('ASSET_SERVER', 'https://static.hasgeek.co.in/')
 #: Secret key
-SECRET_KEY = 'make this something random'
+SECRET_KEY = os.environ.get('SECRET_KEY', 'make this something random')
 #: Cache type
-CACHE_TYPE = 'redis'
-#: Timezone
-TIMEZONE = 'Asia/Kolkata'
-#: Lastuser server
-LASTUSER_SERVER = 'https://auth.hasgeek.com/'
-#: Lastuser client id
-LASTUSER_CLIENT_ID = ''
-#: Lastuser client secret
-LASTUSER_CLIENT_SECRET = ''
-#: Mail settings
-#: MAIL_FAIL_SILENTLY : default True
-#: MAIL_SERVER : default 'localhost'
-#: MAIL_PORT : default 25
-#: MAIL_USE_TLS : default False
-#: MAIL_USE_SSL : default False
-#: MAIL_USERNAME : default None
-#: MAIL_PASSWORD : default None
-#: MAIL_DEFAULT_SENDER : default None
-MAIL_FAIL_SILENTLY = False
-MAIL_SERVER = 'localhost'
-MAIL_DEFAULT_SENDER = 'HasGeek <test@example.com>'
-DEFAULT_MAIL_SENDER = MAIL_DEFAULT_SENDER  # For compatibility with older Flask-Mail
-#: Logging: recipients of error emails
-ADMINS = []
-#: Log file
-LOGFILE = 'error.log'
+CACHE_TYPE = os.environ.get('CACHE_TYPE', 'redis')
 # redis settings for RQ
-REDIS_URL = 'redis://localhost:6379/0'
+REDIS_URL = os.environ.get('REDIS_URL', 'redis://localhost:6379/0')
+#: Timezone
+TIMEZONE = os.environ.get('TIMEZONE', 'Asia/Kolkata')
+#: Lastuser server
+LASTUSER_SERVER = os.environ.get('LASTUSER_SERVER', 'https://auth.hasgeek.com/')
+#: Lastuser client id
+LASTUSER_CLIENT_ID = os.environ.get('LASTUSER_CLIENT_ID', '')
+#: Lastuser client secret
+LASTUSER_CLIENT_SECRET = os.environ.get('LASTUSER_CLIENT_SECRET', '')
+#: Mail settings
+MAIL_FAIL_SILENTLY = os.environ.get('MAIL_FAIL_SILENTLY', 'True') == 'True'
+MAIL_SERVER = os.environ.get('MAIL_SERVER', 'localhost')
+MAIL_PORT = int(os.environ.get('MAIL_PORT', 25))
+MAIL_USE_TLS = os.environ.get('MAIL_USE_TLS', 'False') == 'True'
+MAIL_USE_SSL = os.environ.get('MAIL_USE_SSL', 'False') == 'True'
+MAIL_USERNAME = os.environ.get('MAIL_USERNAME', None)
+MAIL_PASSWORD = os.environ.get('MAIL_PASSWORD', None)
+MAIL_DEFAULT_SENDER = os.environ.get('MAIL_DEFAULT_SENDER', 'HasGeek <test@example.com>')
+DEFAULT_MAIL_SENDER = os.environ.get('DEFAULT_MAIL_SENDER', MAIL_DEFAULT_SENDER)  # For compatibility with older Flask-Mail
+#: Logging: recipients of error emails
+ADMINS = json.loads(os.environ.get('ADMINS', '[]'))
+#: Log file
+LOGFILE = os.environ.get('LOGFILE', 'error.log')


### PR DESCRIPTION
This is required because we're moving to a new deployment system where creating and editing configuration variables by hand should not be encouraged. This PR introduces a stopgap solution to read required variables from environment. There might be more elegant solutions to this.

The intended flow here could be, after cloning the repo, make a copy of settings-sample.py to production.py and then read everything from environment.