### PR TITLE
Rename models, use UUID fkey to user table

### DIFF
--- a/hasmail/templates/dashboard.html.jinja2
+++ b/hasmail/templates/dashboard.html.jinja2
@@ -23,7 +23,7 @@
 {% endblock %}
 
 {% block contentpane %}
-  {%- if mailer %}
+  {%- if mailers %}
     <p>
       {% trans %}Pick a mailer from the sidebar or send a new one.{% endtrans %}
     </p>

--- a/hasmail/templates/dashboard.html.jinja2
+++ b/hasmail/templates/dashboard.html.jinja2
@@ -10,12 +10,12 @@
   </div>
 #}
   <ul class="nav nav-pills nav-stacked nav-pills-filling nav-point-right">
-    {%- if campaigns %}{% for c in campaigns %}
-      <li><a href="{{ c.url_for() }}">{{ c.title }}
-        {%- if c.status == STATUS.DRAFT %} <i class="fa fa-pencil"></i>
-        {%- elif c.status == STATUS.QUEUED %} <i class="fa fa-clock-o"></i>
-        {%- elif c.status == STATUS.SENDING %} <i class="fa fa-spin fa-spinner"></i>
-        {%- elif c.status == STATUS.SENT %} <i class="fa fa-envelope-o"></i>
+    {%- if mailers %}{% for mailer in mailers %}
+      <li><a href="{{ mailer.url_for() }}">{{ mailer.title }}
+        {%- if mailer.status == STATUS.DRAFT %} <i class="fa fa-pencil"></i>
+        {%- elif mailer.status == STATUS.QUEUED %} <i class="fa fa-clock-o"></i>
+        {%- elif mailer.status == STATUS.SENDING %} <i class="fa fa-spin fa-spinner"></i>
+        {%- elif mailer.status == STATUS.SENT %} <i class="fa fa-envelope-o"></i>
         {%- endif -%}
       </a></li>
     {% endfor %}{% endif %}
@@ -23,19 +23,19 @@
 {% endblock %}
 
 {% block contentpane %}
-  {%- if campaigns %}
+  {%- if mailer %}
     <p>
-      {% trans %}Pick an email from the sidebar or send a new one.{% endtrans %}
+      {% trans %}Pick a mailer from the sidebar or send a new one.{% endtrans %}
     </p>
   {%- else %}
     <p>
-      {% trans %}You haven’t written any mail yet.{% endtrans %}
+      {% trans %}You haven’t composed a mailer yet.{% endtrans %}
     </p>
   {%- endif %}
   <form method="POST">
     {{ form.hidden_tag() }}
     <p>
-      <button type="submit" class="btn btn-primary">{% trans %}New email{% endtrans %}</button>
+      <button type="submit" class="btn btn-primary">{% trans %}New mailer{% endtrans %}</button>
     </p>
   </form>
 {% endblock %}

--- a/hasmail/views/index.py
+++ b/hasmail/views/index.py
@@ -1,9 +1,10 @@
 """Index views."""
 
-from flask import g, redirect, render_template, url_for
+from flask import redirect, render_template, url_for
 from flask.typing import ResponseReturnValue
 
 from baseframe import forms
+from coaster.auth import current_auth
 
 from .. import _, app, lastuser
 from ..models import Mailer, MailerState, db
@@ -11,7 +12,7 @@ from ..models import Mailer, MailerState, db
 
 @app.route('/')
 def index() -> ResponseReturnValue:
-    if g.user:
+    if current_auth:
         return redirect(url_for('dashboard'), code=303)
     return render_template('index.html.jinja2')
 
@@ -23,13 +24,13 @@ def index() -> ResponseReturnValue:
 def dashboard() -> ResponseReturnValue:
     form = forms.Form()
     if form.validate_on_submit():
-        mailer = Mailer(title=_("Untitled Email"), user=g.user)
+        mailer = Mailer(title=_("Untitled Email"), user=current_auth.user)
         db.session.add(mailer)
         db.session.commit()
         return redirect(mailer.url_for(), 303)
     return render_template(
         'dashboard.html.jinja2',
-        campaigns=g.user.campaigns,
+        mailers=current_auth.user.mailers,
         form=form,
         wstep=1,
         STATUS=MailerState,

--- a/migrations/versions/1ba0d0459d7f_drop_linkgroup.py
+++ b/migrations/versions/1ba0d0459d7f_drop_linkgroup.py
@@ -1,0 +1,26 @@
+"""Drop linkgroup
+
+Revision ID: 1ba0d0459d7f
+Revises: 60b9647f38c2
+Create Date: 2023-07-07 12:26:00.690352
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '1ba0d0459d7f'
+down_revision = '60b9647f38c2'
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('email_recipient', schema=None) as batch_op:
+        batch_op.drop_column('linkgroup')
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('email_recipient', schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column('linkgroup', sa.INTEGER(), autoincrement=False, nullable=True)
+        )

--- a/migrations/versions/2ff3aaf78532_drop_unused_trackclicks_flag.py
+++ b/migrations/versions/2ff3aaf78532_drop_unused_trackclicks_flag.py
@@ -1,0 +1,29 @@
+"""Drop unused trackclicks flag
+
+Revision ID: 2ff3aaf78532
+Revises: c781ab2adda3
+Create Date: 2023-07-07 13:49:21.176325
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '2ff3aaf78532'
+down_revision = 'c781ab2adda3'
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('email_campaign', schema=None) as batch_op:
+        batch_op.drop_column('trackclicks')
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('email_campaign', schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                'trackclicks', sa.Boolean(), nullable=False, server_default=sa.false()
+            )
+        )
+        batch_op.alter_column('trackclicks', server_default=None)

--- a/migrations/versions/60b9647f38c2_rename_campaign_id_to_mailer_id.py
+++ b/migrations/versions/60b9647f38c2_rename_campaign_id_to_mailer_id.py
@@ -1,0 +1,66 @@
+"""Rename campaign_id to mailer_id
+
+Revision ID: 60b9647f38c2
+Revises: 1da0e1b89f2a
+Create Date: 2023-07-07 11:56:09.339548
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '60b9647f38c2'
+down_revision = '1da0e1b89f2a'
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('email_draft', schema=None) as batch_op:
+        batch_op.alter_column('campaign_id', new_column_name='mailer_id')
+        batch_op.drop_constraint('email_draft_campaign_id_url_id_key', type_='unique')
+        batch_op.drop_constraint('email_draft_campaign_id_fkey', type_='foreignkey')
+        batch_op.create_unique_constraint(
+            'email_draft_mailer_id_url_id_key', ['mailer_id', 'url_id']
+        )
+        batch_op.create_foreign_key(
+            'email_draft_mailer_id_fkey', 'email_campaign', ['mailer_id'], ['id']
+        )
+
+    with op.batch_alter_table('email_recipient', schema=None) as batch_op:
+        batch_op.alter_column('campaign_id', new_column_name='mailer_id')
+        batch_op.drop_constraint(
+            'email_recipient_campaign_id_url_id_key', type_='unique'
+        )
+        batch_op.drop_constraint('email_recipient_campaign_id_fkey', type_='foreignkey')
+        batch_op.create_unique_constraint(
+            'email_recipient_mailer_id_url_id_key', ['mailer_id', 'url_id']
+        )
+        batch_op.create_foreign_key(
+            'email_recipient_mailer_id_fkey', 'email_campaign', ['mailer_id'], ['id']
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('email_recipient', schema=None) as batch_op:
+        batch_op.alter_column('mailer_id', new_column_name='campaign_id')
+        batch_op.drop_constraint('email_recipient_mailer_id_fkey', type_='foreignkey')
+        batch_op.create_foreign_key(
+            'email_recipient_campaign_id_fkey',
+            'email_campaign',
+            ['campaign_id'],
+            ['id'],
+        )
+        batch_op.drop_constraint('email_recipient_mailer_id_url_id_key', type_='unique')
+        batch_op.create_unique_constraint(
+            'email_recipient_campaign_id_url_id_key', ['campaign_id', 'url_id']
+        )
+
+    with op.batch_alter_table('email_draft', schema=None) as batch_op:
+        batch_op.alter_column('mailer_id', new_column_name='campaign_id')
+        batch_op.drop_constraint('email_draft_mailer_id_fkey', type_='foreignkey')
+        batch_op.create_foreign_key(
+            'email_draft_campaign_id_fkey', 'email_campaign', ['campaign_id'], ['id']
+        )
+        batch_op.drop_constraint('email_draft_mailer_id_url_id_key', type_='unique')
+        batch_op.create_unique_constraint(
+            'email_draft_campaign_id_url_id_key', ['campaign_id', 'url_id']
+        )

--- a/migrations/versions/6e3b5579313e_replace_user_userid_with_uuid.py
+++ b/migrations/versions/6e3b5579313e_replace_user_userid_with_uuid.py
@@ -1,0 +1,64 @@
+"""Replace user.userid with uuid
+
+Revision ID: 6e3b5579313e
+Revises: 1ba0d0459d7f
+Create Date: 2023-07-07 12:34:58.418861
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from coaster.utils import uuid_from_base64, uuid_to_base64
+
+# revision identifiers, used by Alembic.
+revision = '6e3b5579313e'
+down_revision = '1ba0d0459d7f'
+
+
+user_table = sa.table(
+    'user',
+    sa.column('id', sa.Integer()),
+    sa.column('userid', sa.Unicode),
+    sa.column('uuid', sa.Uuid()),
+)
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('uuid', sa.Uuid(), nullable=True))
+
+    conn = op.get_bind()
+    users = conn.execute(sa.select(user_table))
+    for user in users:
+        op.execute(
+            user_table.update()
+            .where(user_table.c.id == user.id)
+            .values(uuid=uuid_from_base64(user.userid))
+        )
+
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.alter_column('uuid', nullable=False)
+        batch_op.create_unique_constraint('user_uuid_key', ['uuid'])
+        batch_op.drop_constraint('user_userid_key', type_='unique')
+        batch_op.drop_column('userid')
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('userid', sa.VARCHAR(length=22), nullable=True))
+
+    conn = op.get_bind()
+    users = conn.execute(sa.select(user_table))
+    for user in users:
+        op.execute(
+            user_table.update()
+            .where(user_table.c.id == user.id)
+            .values(userid=uuid_to_base64(user.uuid))
+        )
+
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.alter_column('userid', nullable=False)
+        batch_op.create_unique_constraint('user_userid_key', ['userid'])
+        batch_op.drop_constraint('user_uuid_key', type_='unique')
+        batch_op.drop_column('uuid')

--- a/migrations/versions/761d820f2eaa_rename_models.py
+++ b/migrations/versions/761d820f2eaa_rename_models.py
@@ -1,0 +1,105 @@
+"""Rename models
+
+Revision ID: 761d820f2eaa
+Revises: 2ff3aaf78532
+Create Date: 2023-07-07 13:58:27.187831
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '761d820f2eaa'
+down_revision = '2ff3aaf78532'
+
+renames = [
+    ('table', 'email_campaign', 'mailer'),
+    ('sequence', 'email_campaign_id_seq', 'mailer_id_seq'),
+    ('constraint', 'mailer', 'email_campaign_pkey', 'mailer_pkey'),
+    ('constraint', 'mailer', 'email_campaign_name_key', 'mailer_name_key'),
+    ('constraint', 'mailer', 'email_campaign_user_uuid_fkey', 'mailer_user_uuid_fkey'),
+    ('table', 'email_recipient', 'mailer_recipient'),
+    ('sequence', 'email_recipient_id_seq', 'mailer_recipient_id_seq'),
+    ('constraint', 'mailer_recipient', 'email_recipient_pkey', 'mailer_recipient_pkey'),
+    (
+        'constraint',
+        'mailer_recipient',
+        'email_recipient_mailer_id_url_id_key',
+        'mailer_recipient_mailer_id_url_id_key',
+    ),
+    (
+        'constraint',
+        'mailer_recipient',
+        'email_recipient_opentoken_key',
+        'mailer_recipient_opentoken_key',
+    ),
+    (
+        'constraint',
+        'mailer_recipient',
+        'email_recipient_rsvptoken_key',
+        'mailer_recipient_rsvptoken_key',
+    ),
+    (
+        'index',
+        'ix_email_recipient_email',
+        'ix_mailer_recipient_email',
+    ),
+    (
+        'index',
+        'ix_email_recipient_md5sum',
+        'ix_mailer_recipient_md5sum',
+    ),
+    ('table', 'email_draft', 'mailer_draft'),
+    ('sequence', 'email_draft_id_seq', 'mailer_draft_id_seq'),
+    ('constraint', 'mailer_draft', 'email_draft_pkey', 'mailer_draft_pkey'),
+    (
+        'constraint',
+        'mailer_draft',
+        'email_draft_mailer_id_url_id_key',
+        'mailer_draft_mailer_id_url_id_key',
+    ),
+    (
+        'constraint',
+        'mailer_draft',
+        'email_draft_mailer_id_fkey',
+        'mailer_draft_mailer_id_fkey',
+    ),
+]
+
+
+def upgrade() -> None:
+    for row in renames:
+        if row[0] == 'table':
+            old_name, new_name = row[1:]
+            op.rename_table(old_name, new_name)
+        elif row[0] == 'sequence':
+            old_name, new_name = row[1:]
+            op.execute(f'ALTER SEQUENCE {old_name} RENAME TO {new_name}')
+        elif row[0] == 'constraint':
+            table_name, old_name, new_name = row[1:]
+            op.execute(
+                f'ALTER TABLE {table_name} RENAME CONSTRAINT'
+                f' {old_name} TO {new_name}'
+            )
+        elif row[0] == 'index':
+            old_name, new_name = row[1:]
+            op.execute(f'ALTER INDEX {old_name} RENAME TO {new_name}')
+
+
+def downgrade() -> None:
+    for row in renames[::-1]:
+        if row[0] == 'table':
+            old_name, new_name = row[1:]
+            op.rename_table(new_name, old_name)
+        elif row[0] == 'sequence':
+            old_name, new_name = row[1:]
+            op.execute(f'ALTER SEQUENCE {new_name} RENAME TO {old_name}')
+        elif row[0] == 'constraint':
+            table_name, old_name, new_name = row[1:]
+            op.execute(
+                f'ALTER TABLE {table_name} RENAME CONSTRAINT'
+                f' {new_name} TO {old_name}'
+            )
+        elif row[0] == 'index':
+            old_name, new_name = row[1:]
+            op.execute(f'ALTER INDEX {new_name} RENAME TO {old_name}')

--- a/migrations/versions/c781ab2adda3_use_uuid_fkey_to_user.py
+++ b/migrations/versions/c781ab2adda3_use_uuid_fkey_to_user.py
@@ -1,0 +1,84 @@
+"""Use uuid fkey to user
+
+Revision ID: c781ab2adda3
+Revises: 6e3b5579313e
+Create Date: 2023-07-07 13:32:39.389807
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'c781ab2adda3'
+down_revision = '6e3b5579313e'
+
+
+user_table = sa.table(
+    'user',
+    sa.column('id', sa.Integer()),
+    sa.column('uuid', sa.Uuid()),
+)
+
+email_campaign_table = sa.table(
+    'email_campaign',
+    sa.column('id', sa.Integer()),
+    sa.column('user_id', sa.Integer()),
+    sa.column('user_uuid', sa.Uuid()),
+)
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('email_campaign', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('user_uuid', sa.Uuid(), nullable=True))
+
+    conn = op.get_bind()
+    campaign_fkeys = conn.execute(
+        sa.select(
+            email_campaign_table.c.id.label('campaign_id'),
+            email_campaign_table.c.user_id.label('user_id'),
+            user_table.c.uuid.label('user_uuid'),
+        ).where(email_campaign_table.c.user_id == user_table.c.id)
+    )
+    for campaign in campaign_fkeys:
+        op.execute(
+            email_campaign_table.update()
+            .where(email_campaign_table.c.id == campaign.campaign_id)
+            .values(user_uuid=campaign.user_uuid)
+        )
+
+    with op.batch_alter_table('email_campaign', schema=None) as batch_op:
+        batch_op.alter_column('user_uuid', nullable=False)
+        batch_op.drop_constraint('email_campaign_user_id_fkey', type_='foreignkey')
+        batch_op.create_foreign_key(
+            'email_campaign_user_uuid_fkey', 'user', ['user_uuid'], ['uuid']
+        )
+        batch_op.drop_column('user_id')
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('email_campaign', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('user_id', sa.Uuid(), nullable=True))
+
+    conn = op.get_bind()
+    campaign_fkeys = conn.execute(
+        sa.select(
+            email_campaign_table.c.id.label('campaign_id'),
+            email_campaign_table.c.user_uuid.label('user_uuid'),
+            user_table.c.id.label('user_id'),
+        ).where(email_campaign_table.c.user_uuid == user_table.c.uuid)
+    )
+    for campaign in campaign_fkeys:
+        op.execute(
+            email_campaign_table.update()
+            .where(email_campaign_table.c.id == campaign.campaign_id)
+            .values(user_id=campaign.user_id)
+        )
+
+    with op.batch_alter_table('email_campaign', schema=None) as batch_op:
+        batch_op.alter_column('user_id', nullable=False)
+        batch_op.drop_constraint('email_campaign_user_id_fkey', type_='foreignkey')
+        batch_op.create_foreign_key(
+            'email_campaign_user_id_fkey', 'user', ['user_id'], ['id']
+        )
+        batch_op.drop_column('user_uuid')


### PR DESCRIPTION
This change prepares Hasmail for merger with Funnel, allowing the mailer models and table data to be directly imported there.